### PR TITLE
fix info helper case nested + text

### DIFF
--- a/app/helpers/dorsale/text_helper.rb
+++ b/app/helpers/dorsale/text_helper.rb
@@ -81,7 +81,7 @@ module Dorsale
       value = object.public_send(attribute)     if value.nil?
       value = t("yes")                          if value === true
       value = t("no")                           if value === false
-      value = object.t("#{attribute}.#{value}") if nested
+      value = object.t("#{attribute}.#{value}") if value.nil? && nested
       value = send(helper, value)               if helper
       value = number(value)                     if value.is_a?(Numeric)
       value = l(value)                          if value.is_a?(Time)


### PR DESCRIPTION
fix case:

    helper.info Model, :state, 'Canceled by me@example.org'

was returning:

    "<div class=\"info\"><strong class=\"info-label\">Model state</strong> : <span class=\"info-value model-state\">Org</span></div>"

now returns:

    "<div class=\"info\"><strong class=\"info-label\">Model state</strong> : <span class=\"info-value model-state\">Canceled by me@example.org</span></div>"
