### PR TITLE
Billing machine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Next version
+- Add `Dorsale::BillingMachine.vat_round_by_line` option
+- Revert default `vat_round_by_line` value introduced in 3.10.0 (it's now false again)
 
 ## 3.13.0
 - Rails 5.2 compatible

--- a/Gemfile
+++ b/Gemfile
@@ -8,8 +8,8 @@ else
 end
 
 gem "rails", "~> 5.2.3"
-gem "agilibox", ">= 1.5.12"
-gem "axlsx", github: "randym/axlsx"
+gem "agilibox", ">= 1.6.0"
+gem "spreadsheet_architect"
 
 gem "bootsnap"
 gem "devise"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,3 @@
-GIT
-  remote: https://github.com/randym/axlsx.git
-  revision: c593a08b2a929dac7aa8dc418b55e26b4c49dc34
-  specs:
-    axlsx (3.0.0.pre)
-      htmlentities (~> 4.3, >= 4.3.4)
-      mimemagic (~> 0.3)
-      nokogiri (~> 1.8, >= 1.8.2)
-      rubyzip (~> 1.2, >= 1.2.1)
-
 PATH
   remote: .
   specs:
@@ -93,19 +83,27 @@ GEM
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
     afm (0.2.2)
-    agilibox (1.5.13)
+    agilibox (1.6.0)
       awesome_print
       pry-rails
       rails-i18n
     arel (9.0.0)
     ast (2.4.0)
-    autoprefixer-rails (9.6.1)
+    autoprefixer-rails (9.6.1.1)
       execjs
     awesome_print (1.8.0)
     axiom-types (0.1.1)
       descendants_tracker (~> 0.0.4)
       ice_nine (~> 0.11.0)
       thread_safe (~> 0.3, >= 0.3.1)
+    axlsx (3.0.0.pre)
+      htmlentities (~> 4.3, >= 4.3.4)
+      mimemagic (~> 0.3)
+      nokogiri (~> 1.8, >= 1.8.2)
+      rubyzip (~> 1.2, >= 1.2.1)
+    axlsx_styler (0.2.0)
+      activesupport (>= 3.1)
+      axlsx (>= 2.0, < 4)
     backports (3.15.0)
     bcrypt (3.1.13)
     better_errors (2.5.1)
@@ -123,7 +121,7 @@ GEM
       autoprefixer-rails (>= 5.2.1)
       sassc (>= 2.0.0)
     builder (3.2.3)
-    bullet (6.0.1)
+    bullet (6.0.2)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
     byebug (11.0.1)
@@ -135,10 +133,13 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
-    carrierwave (1.3.1)
-      activemodel (>= 4.0.0)
-      activesupport (>= 4.0.0)
-      mime-types (>= 1.16)
+    carrierwave (2.0.0)
+      activemodel (>= 5.0.0)
+      activesupport (>= 5.0.0)
+      addressable (~> 2.6)
+      image_processing (~> 1.1)
+      mimemagic (>= 0.3.0)
+      mini_mime (>= 0.1.3)
     chartkick (3.2.1)
     choice (0.2.0)
     cliver (0.3.2)
@@ -188,10 +189,10 @@ GEM
       thread_safe (~> 0.3, >= 0.3.1)
     desktop_delivery (1.0.0)
       launchy
-    devise (4.6.2)
+    devise (4.7.0)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
-      railties (>= 4.1.0, < 6.0)
+      railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
     devise-bootstrap-views (1.1.0)
@@ -199,6 +200,7 @@ GEM
       devise (>= 4.6)
     diff-lcs (1.3)
     docile (1.3.2)
+    dry-inflector (0.1.2)
     equalizer (0.0.11)
     erubi (1.8.0)
     execjs (2.7.0)
@@ -220,6 +222,9 @@ GEM
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
+    image_processing (1.9.3)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.13, < 3)
     jaro_winkler (1.5.3)
     jquery-rails (4.3.5)
       rails-dom-testing (>= 1, < 3)
@@ -269,7 +274,7 @@ GEM
     nilify_blanks (1.3.0)
       activerecord (>= 3.0.0)
       activesupport (>= 3.0.0)
-    nio4r (2.4.0)
+    nio4r (2.5.0)
     nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     orm_adapter (0.5.0)
@@ -349,6 +354,10 @@ GEM
     responders (3.0.0)
       actionpack (>= 5.0)
       railties (>= 5.0)
+    rodf (1.1.0)
+      builder (>= 3.0)
+      dry-inflector (~> 0.1)
+      rubyzip (>= 1.0)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -389,6 +398,8 @@ GEM
     ruby-graphviz (1.2.4)
     ruby-progressbar (1.10.1)
     ruby-rc4 (0.1.5)
+    ruby-vips (2.0.14)
+      ffi (~> 1.9)
     ruby_dep (1.5.0)
     rubyzip (1.2.3)
     sass (3.7.4)
@@ -396,15 +407,16 @@ GEM
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    sass-rails (5.0.7)
-      railties (>= 4.0.0, < 6)
-      sass (~> 3.1)
-      sprockets (>= 2.8, < 4.0)
-      sprockets-rails (>= 2.0, < 4.0)
-      tilt (>= 1.1, < 3)
-    sassc (2.0.1)
+    sass-rails (6.0.0)
+      sassc-rails (~> 2.1, >= 2.1.1)
+    sassc (2.2.0)
       ffi (~> 1.9)
-      rake
+    sassc-rails (2.1.2)
+      railties (>= 4.0.0)
+      sassc (>= 2.0)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     select2-rails (4.0.3)
       thor (~> 0.14)
     shoulda-matchers (4.1.2)
@@ -424,6 +436,10 @@ GEM
       actionpack (>= 3.1)
       railties (>= 3.1)
       slim (>= 3.0, < 5.0)
+    spreadsheet_architect (3.2.1)
+      axlsx (>= 2, < 4)
+      axlsx_styler (>= 0.1.7, < 2)
+      rodf (>= 1.0.0, < 2)
     spring (2.1.0)
     spring-commands-cucumber (1.0.1)
       spring (>= 0.9.1)
@@ -472,8 +488,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  agilibox (>= 1.5.12)
-  axlsx!
+  agilibox (>= 1.6.0)
   better_errors
   bootsnap
   bootstrap-sass
@@ -510,6 +525,7 @@ DEPENDENCIES
   select2-rails
   shoulda-matchers
   simplecov
+  spreadsheet_architect
   spring
   spring-commands-cucumber
   spring-commands-rspec

--- a/app/assets/javascripts/dorsale/engines/billing_machine.coffee.erb
+++ b/app/assets/javascripts/dorsale/engines/billing_machine.coffee.erb
@@ -1,5 +1,7 @@
 @BillingMachine = {}
 
+BillingMachine.vat_round_by_line = <%= Dorsale::BillingMachine.vat_round_by_line %>
+
 BillingMachine.settings =
   precision : 2
   thousand  : " " # nbsp
@@ -18,7 +20,7 @@ BillingMachine.num2str = (num) ->
   accounting.formatNumber(num, settings.precision, settings.thousand, settings.decimal)
 
 BillingMachine.round2 = (num) ->
-  return +(Math.round(num + "e+2")  + "e-2")
+  return +(Math.round(num + "e+2") + "e-2")
 
 BillingMachine.updateTotals = ->
   total_excluding_taxes = 0.0
@@ -42,7 +44,7 @@ BillingMachine.updateTotals = ->
   discount_rate = commercial_discount / raw_total_excluding_taxes
 
   # VAT amount based on each line total with discount rate
-  vat_amount = 0.0
+  total_vat_amount = 0.0
   $("#billing_machine-form .line").map ->
     return if parseInt($(this).find("input[name*=destroy]").val()) == 1
 
@@ -55,11 +57,13 @@ BillingMachine.updateTotals = ->
 
     line_total = BillingMachine.str2num $(this).find(".line-total input").val()
     discounted_line_total = line_total - (line_total * discount_rate)
-    line_vat_amount = BillingMachine.round2(discounted_line_total * vat_rate / 100)
-    vat_amount += line_vat_amount
-  $(".vat_amount input").val BillingMachine.num2str vat_amount
+    line_vat_amount = discounted_line_total * vat_rate / 100
+    line_vat_amount = BillingMachine.round2(line_vat_amount) if BillingMachine.vat_round_by_line
+    total_vat_amount += line_vat_amount
+    total_vat_amount = BillingMachine.round2(total_vat_amount)
+  $(".vat_amount input").val BillingMachine.num2str total_vat_amount
 
-  total_including_taxes = total_excluding_taxes + vat_amount
+  total_including_taxes = total_excluding_taxes + total_vat_amount
   $(".total_including_taxes input").val BillingMachine.num2str total_including_taxes
 
   # Advances is for invoices only, not for quotations

--- a/app/models/dorsale/billing_machine.rb
+++ b/app/models/dorsale/billing_machine.rb
@@ -13,6 +13,13 @@ module Dorsale::BillingMachine
       @vat_mode = new_mode
     end
 
+    def vat_round_by_line
+      @vat_round_by_line = false if @vat_round_by_line.nil?
+      @vat_round_by_line
+    end
+
+    attr_writer :vat_round_by_line
+
     def invoice_pdf_model
       "::Dorsale::BillingMachine::Invoice#{vat_mode.to_s.capitalize}VatPdf".constantize
     end

--- a/app/models/dorsale/billing_machine/invoice.rb
+++ b/app/models/dorsale/billing_machine/invoice.rb
@@ -57,7 +57,7 @@ class Dorsale::BillingMachine::Invoice < ::Dorsale::ApplicationRecord
     lines.each(&:update_total)
     apply_vat_rate_to_lines
 
-    lines_sum = lines.map(&:total).sum
+    lines_sum = lines.map(&:total).sum.round(2)
 
     self.total_excluding_taxes = lines_sum - commercial_discount
 
@@ -71,8 +71,12 @@ class Dorsale::BillingMachine::Invoice < ::Dorsale::ApplicationRecord
 
     lines.each do |line|
       line_total = line.total - (line.total * discount_rate)
-      self.vat_amount += (line_total * line.vat_rate / 100.0).round(2)
+      line_vat = (line_total * line.vat_rate / 100.0)
+      line_vat = line_vat.round(2) if Dorsale::BillingMachine.vat_round_by_line
+      self.vat_amount += line_vat
     end
+
+    self.vat_amount = vat_amount.round(2)
 
     self.total_including_taxes = total_excluding_taxes + vat_amount
     self.balance               = total_including_taxes - advance

--- a/app/models/dorsale/billing_machine/quotation.rb
+++ b/app/models/dorsale/billing_machine/quotation.rb
@@ -76,8 +76,12 @@ class Dorsale::BillingMachine::Quotation < ::Dorsale::ApplicationRecord
 
     lines.each do |line|
       line_total = line.total - (line.total * discount_rate)
-      self.vat_amount += (line_total * line.vat_rate / 100.0).round(2)
+      line_vat = (line_total * line.vat_rate / 100.0)
+      line_vat = line_vat.round(2) if Dorsale::BillingMachine.vat_round_by_line
+      self.vat_amount += line_vat
     end
+
+    self.vat_amount = vat_amount.round(2)
 
     self.total_including_taxes = total_excluding_taxes + vat_amount
   end

--- a/spec/models/dorsale/billing_machine/invoice_line_spec.rb
+++ b/spec/models/dorsale/billing_machine/invoice_line_spec.rb
@@ -42,11 +42,11 @@ describe Dorsale::BillingMachine::InvoiceLine, type: :model do
 
   it "should update the total upon save" do
     line = create(:billing_machine_invoice_line, quantity: 12.34, unit_price: 12.34, total: 0)
-    expect(line.total).to eq(152.28)
+    expect(line.total.to_f).to eq 152.28
   end
 
   it "should update the total gracefully with invalid data" do
     line = create(:billing_machine_invoice_line, quantity: nil, unit_price: nil, total: 0)
-    expect(line.total).to eq(0)
+    expect(line.total.to_f).to eq 0
   end
 end

--- a/spec/models/dorsale/billing_machine/quotation_line_spec.rb
+++ b/spec/models/dorsale/billing_machine/quotation_line_spec.rb
@@ -41,11 +41,11 @@ describe Dorsale::BillingMachine::QuotationLine do
 
   it "should update the total upon save" do
     line = create(:billing_machine_quotation_line, quantity: 12.34, unit_price: 12.34, total: 0)
-    expect(line.total).to eq(152.28)
+    expect(line.total.to_f).to eq 152.28
   end
 
   it "should update the total gracefully with invalid data" do
     line = create(:billing_machine_quotation_line, quantity: nil, unit_price: nil, total: 0)
-    expect(line.total).to eq(0)
+    expect(line.total.to_f).to eq 0
   end
 end

--- a/spec/models/dorsale/billing_machine/quotation_spec.rb
+++ b/spec/models/dorsale/billing_machine/quotation_spec.rb
@@ -152,30 +152,47 @@ describe Dorsale::BillingMachine::Quotation do
       Dorsale::BillingMachine.vat_mode = :single
     end
 
-    it "should round numbers" do
-      quotation = create(:billing_machine_quotation,
-        :commercial_discount => 0,
-      )
+    describe "VAT round" do
+      let(:quotation) {
+        quotation = create(:billing_machine_quotation,
+          :commercial_discount => 0,
+        )
 
-      create(:billing_machine_quotation_line,
-        :quantity   => 12.34,
-        :unit_price => 12.34,
-        :vat_rate   => 20,
-        :quotation  => quotation,
-      ) # total 152.28
+        create(:billing_machine_quotation_line,
+          :quantity   => 12.34,
+          :unit_price => 12.34,
+          :vat_rate   => 20,
+          :quotation  => quotation,
+        ) # vat 30.45512 / total 152.2756
 
-      create(:billing_machine_quotation_line,
-        :quantity   => 12.34,
-        :unit_price => 12.34,
-        :vat_rate   => 20,
-        :quotation  => quotation,
-      ) # total 152.28
+        create(:billing_machine_quotation_line,
+          :quantity   => 12.34,
+          :unit_price => 12.34,
+          :vat_rate   => 20,
+          :quotation  => quotation,
+        ) # vat 30.45512 / total 152.2756
 
-      expect(quotation.total_excluding_taxes).to eq(304.56)
-      expect(quotation.vat_amount).to eq(60.92)
-      expect(quotation.total_including_taxes).to eq(365.48)
-      expect(quotation.balance).to eq(365.48)
-    end
+        quotation
+      }
+
+      after { Dorsale::BillingMachine.vat_round_by_line = nil }
+
+      it "should round VAT by line" do
+        Dorsale::BillingMachine.vat_round_by_line = true
+        expect(quotation.total_excluding_taxes.to_f).to eq(304.56)
+        expect(quotation.vat_amount.to_f).to eq(60.92)
+        expect(quotation.total_including_taxes.to_f).to eq(365.48)
+        expect(quotation.balance.to_f).to eq(365.48)
+      end
+
+      it "should round VAT globally" do
+        Dorsale::BillingMachine.vat_round_by_line = false
+        expect(quotation.total_excluding_taxes.to_f).to eq(304.56)
+        expect(quotation.vat_amount.to_f).to eq(60.91)
+        expect(quotation.total_including_taxes.to_f).to eq(365.47)
+        expect(quotation.balance.to_f).to eq(365.47)
+      end
+    end # describe "VAT round" do
 
     it "should work fine even with empty lines" do
       quotation = create(:billing_machine_quotation, commercial_discount: nil)

--- a/spec/models/dorsale/billing_machine_spec.rb
+++ b/spec/models/dorsale/billing_machine_spec.rb
@@ -5,31 +5,53 @@ RSpec.describe Dorsale::BillingMachine do
     ::Dorsale::BillingMachine
   }
 
-  it "default vat_mode should be :single" do
-    expect(bm.vat_mode).to eq :single
-    expect(bm.invoice_pdf_model).to eq Dorsale::BillingMachine::InvoiceSingleVatPdf
-    expect(bm.quotation_pdf_model).to eq Dorsale::BillingMachine::QuotationSingleVatPdf
-  end
+  describe "::vat_mode" do
+    it "default vat_mode should be :single" do
+      expect(bm.vat_mode).to eq :single
+      expect(bm.invoice_pdf_model).to eq Dorsale::BillingMachine::InvoiceSingleVatPdf
+      expect(bm.quotation_pdf_model).to eq Dorsale::BillingMachine::QuotationSingleVatPdf
+    end
 
-  it "vat_mode should accept :multiple value" do
-    bm.vat_mode = :multiple
-    expect(bm.vat_mode).to eq :multiple
-    expect(bm.invoice_pdf_model).to eq Dorsale::BillingMachine::InvoiceMultipleVatPdf
-    expect(bm.quotation_pdf_model).to eq Dorsale::BillingMachine::QuotationMultipleVatPdf
-  end
+    it "vat_mode should accept :multiple value" do
+      bm.vat_mode = :multiple
+      expect(bm.vat_mode).to eq :multiple
+      expect(bm.invoice_pdf_model).to eq Dorsale::BillingMachine::InvoiceMultipleVatPdf
+      expect(bm.quotation_pdf_model).to eq Dorsale::BillingMachine::QuotationMultipleVatPdf
+    end
 
-  it "vat_mode should not accept :abc value" do
-    expect {
-      bm.vat_mode = :abc
-    }.to raise_error(RuntimeError)
-  end
+    it "vat_mode should not accept :abc value" do
+      expect {
+        bm.vat_mode = :abc
+      }.to raise_error(RuntimeError)
+    end
+  end # describe "::vat_mode"
 
-  it "default currency should be €" do
-    expect(bm.default_currency).to eq "€"
-  end
+  describe "::vat_round_by_line" do
+    after { Dorsale::BillingMachine.vat_round_by_line = nil }
 
-  it "assign an other default currency" do
-    bm.default_currency = "$"
-    expect(bm.default_currency).to eq "$"
-  end
+    it "should return default value" do
+      expect(Dorsale::BillingMachine.vat_round_by_line).to eq false
+    end
+
+    it "should assign false value" do
+      Dorsale::BillingMachine.vat_round_by_line = false
+      expect(Dorsale::BillingMachine.vat_round_by_line).to eq false
+    end
+
+    it "should assign true value" do
+      Dorsale::BillingMachine.vat_round_by_line = true
+      expect(Dorsale::BillingMachine.vat_round_by_line).to eq true
+    end
+  end # describe "::vat_round_by_line"
+
+  describe "::default_currency" do
+    it "default currency should be €" do
+      expect(bm.default_currency).to eq "€"
+    end
+
+    it "assign an other default currency" do
+      bm.default_currency = "$"
+      expect(bm.default_currency).to eq "$"
+    end
+  end # describe "::default_currency"
 end


### PR DESCRIPTION
@marc-agilidee J'ai rajouté une option pour choisir d'arrondir la TVA ligne par ligne ou de façon globale à la facture.

Plus besoin de faire des overrides de la méthode `update_totals` dans les projets.

Au passage, j'ai repassé à un arrondi global par défaut parce que c'est ce que veulent quasiment tous les clients.

Il faudra faire attention lors des updates des app à configurer la bonne valeur (je crois que SCPL est le seul à utiliser la TVA arrondie par ligne) et à virer les overrides.

Exemple de factures (TVA avec 1c de différence) : 
[global.pdf](https://github.com/agilidee/dorsale/files/3550349/global.pdf)
[par ligne.pdf](https://github.com/agilidee/dorsale/files/3550350/par.ligne.pdf)
